### PR TITLE
Add support for iOS simulator

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -40,6 +40,7 @@ kotlin {
     macosArm64()
     iosArm64()
     iosX64()
+    iosSimulatorArm64()
     @OptIn(ExperimentalWasmDsl::class)
     wasmJs {
         browser()


### PR DESCRIPTION
Add iosSimulatorArm64() to targets so it supports normal project setup with iOS development.